### PR TITLE
Add try_append and try_update to return Result-types

### DIFF
--- a/src/serde_error.rs
+++ b/src/serde_error.rs
@@ -6,9 +6,11 @@ pub enum IdentifiedVecOfSerdeFailure {
 }
 
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
-pub enum InsertionFailure {
-    #[error("Duplicate element with same id found")]
-    ElementWithSameIDFound,
+pub enum Error {
+    #[error("Element with that id not found in collection")]
+    ExpectedElementNotPresent,
     #[error("Duplicate element with same value found")]
     ElementWithSameValueFound,
+    #[error("Duplicate element with same ID found")]
+    ElementWithSameIDFound,
 }

--- a/src/serde_error.rs
+++ b/src/serde_error.rs
@@ -4,3 +4,11 @@ pub enum IdentifiedVecOfSerdeFailure {
     #[error("Duplicate element at offset {0}")]
     DuplicateElementsAtIndex(usize),
 }
+
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
+pub enum InsertionFailure {
+    #[error("Duplicate element with same id found")]
+    ElementWithSameIDFound,
+    #[error("Duplicate element with same value found")]
+    ElementWithSameValueFound,
+}

--- a/src/serde_error.rs
+++ b/src/serde_error.rs
@@ -7,10 +7,10 @@ pub enum IdentifiedVecOfSerdeFailure {
 
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 pub enum Error {
-    #[error("Element with that id not found in collection")]
-    ExpectedElementNotPresent,
-    #[error("Duplicate element with same value found")]
-    ElementWithSameValueFound,
-    #[error("Duplicate element with same ID found")]
-    ElementWithSameIDFound,
+    #[error("Element with that id: `{0}` not found in collection")]
+    ExpectedElementNotPresent(String),
+    #[error("Duplicate element with same value: `{0}` found")]
+    ElementWithSameValueFound(String),
+    #[error("Duplicate element with same ID: `{0}` found")]
+    ElementWithSameIDFound(String),
 }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -577,7 +577,7 @@ where
     /// - Complexity: The operation is expected to perform O(1) copy, hash, and compare operations on
     ///   the `ID` type, if it implements high-quality hashing.
     #[inline]
-    pub fn try_append(&mut self, element: Element) -> Result<(bool, usize), Error> {
+    pub fn try_append_new(&mut self, element: Element) -> Result<(bool, usize), Error> {
         let id = self.id(&element);
 
         if self.contains_id(&id) {
@@ -660,8 +660,7 @@ where
             .expect("Replaced old value");
     }
 
-    /// Try to add the given element to the `identified_vec` unconditionally, either appending it to the `identified_vec``, or
-    /// replacing an existing value if it's already present.
+    /// Try to update the given element to the `identified_vec` if a element with the same ID is already present.
     ///
     /// - Parameter item: The value to append or replace.
     /// - Returns: A Result with either the original element that was replaced by this operation, or a Error, `Error::ExpectedElementNotPresent`, specifying that the expected element is not present within the collection.

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1,4 +1,4 @@
-use crate::InsertionFailure;
+use crate::serde_error::Error;
 use std::collections::HashMap;
 use std::fmt::{Debug, Display};
 use std::hash::{Hash, Hasher};
@@ -535,6 +535,59 @@ where
     }
 }
 
+impl<ID, Element> IdentifiedVec<ID, Element>
+where
+    ID: Eq + Hash + Clone + Debug,
+    Element: Eq + Hash + Clone + Debug,
+{
+    /// Try append a new unique member to the end of the `identified_vec`, if the `identified_vec` already contains the Value or ID a Error will be returned.
+    ///
+    /// - Parameter item: The element to add to the `identified_vec`.
+    /// - Returns: Either a Ok() with a pair `(inserted, index)`, where `inserted` is a Boolean value indicating whether
+    ///   the operation added a new element, and `index` is the index of `item` in the resulting
+    ///   `identified_vec`. If the given ID already exist `Error::ElementWithSameIDFound` willl be returned and if the value pre-exists within the collection the function call returns `Error::ElementWithSameValueFound`.
+    /// - Complexity: The operation is expected to perform O(1) copy, hash, and compare operations on
+    ///   the `ID` type, if it implements high-quality hashing.
+    #[inline]
+    pub fn try_append_unique_element(&mut self, element: Element) -> Result<(bool, usize), Error> {
+        let id = self.id(&element);
+
+        if let Some(value) = self.get(&id) {
+            if value == &element {
+                return Err(Error::ElementWithSameValueFound);
+            } else {
+                return Err(Error::ElementWithSameIDFound);
+            }
+        }
+
+        Ok(self.append(element))
+    }
+}
+
+impl<ID, Element> IdentifiedVec<ID, Element>
+where
+    ID: Eq + Hash + Clone + Debug,
+{
+    /// Try append a new member to the end of the `identified_vec`, if the `identified_vec` already contains the element a Error will be returned.
+    ///
+    /// - Parameter item: The element to add to the `identified_vec`.
+    /// - Returns: Either a Ok() with a pair `(inserted, index)`, where `inserted` is a Boolean value indicating whether
+    ///   the operation added a new element, and `index` is the index of `item` in the resulting
+    ///   `identified_vec`. If the given ID pre-exists within the collection the function call returns `Error::ElementWithSameIDFound`.
+    /// - Complexity: The operation is expected to perform O(1) copy, hash, and compare operations on
+    ///   the `ID` type, if it implements high-quality hashing.
+    #[inline]
+    pub fn try_append(&mut self, element: Element) -> Result<(bool, usize), Error> {
+        let id = self.id(&element);
+
+        if self.contains_id(&id) {
+            return Err(Error::ElementWithSameIDFound);
+        }
+
+        Ok(self.append(element))
+    }
+}
+
 ///////////////////////
 ////  Public Insert ///
 ///////////////////////
@@ -567,28 +620,6 @@ where
         I: IntoIterator<Item = Element>,
     {
         other.into_iter().for_each(|i| _ = self.append(i))
-    }
-
-    /// Try Append a new member to the end of the `identified_vec`, if the `identified_vec` already contains the element a InsertionError will be returned.
-    ///
-    /// - Parameter item: The element to add to the `identified_vec`.
-    /// - Returns: Either a Ok() with a pair `(inserted, index)`, where `inserted` is a Boolean value indicating whether
-    ///   the operation added a new element, and `index` is the index of `item` in the resulting
-    ///   `identified_vec`. If the given ID or Value pre-exists within the collection the function call returns a InsertionFailure Error specifying the reason.
-    /// - Complexity: The operation is expected to perform O(1) copy, hash, and compare operations on
-    ///   the `ID` type, if it implements high-quality hashing.
-    #[inline]
-    pub fn try_append(&mut self, element: Element) -> Result<(bool, usize), InsertionFailure> {
-        let id = self.id(&element);
-        if self.index_of_id(&id).is_some() {
-            return Err(InsertionFailure::ElementWithSameIDFound);
-        }
-
-        if self.contains(&element) {
-            return Err(InsertionFailure::ElementWithSameValueFound);
-        }
-
-        Ok(self.insert(element, self.end_index()))
     }
 
     /// Adds the given element to the `identified_vec` unconditionally, either appending it to the `identified_vec``, or
@@ -633,21 +664,19 @@ where
     /// replacing an existing value if it's already present.
     ///
     /// - Parameter item: The value to append or replace.
-    /// - Returns: A Result with either the original element that was replaced by this operation, or `None` if the value was
-    ///   appended to the end of the collection. If the given element already exists within the collection the function call returns a InsertionFailure.
+    /// - Returns: A Result with either the original element that was replaced by this operation, or a Error, `Error::ExpectedElementNotPresent`, specifying that the expected element is not present within the collection.
     /// - Complexity: The operation is expected to perform amortized O(1) copy, hash, and compare
     ///   operations on the `ID` type, if it implements high-quality hashing.
     #[inline]
-    pub fn try_update_or_append(
-        &mut self,
-        element: Element,
-    ) -> Result<Option<Element>, InsertionFailure> {
+    pub fn try_update(&mut self, element: Element) -> Result<Element, Error> {
         let id = self.id(&element);
-        if self.index_of_id(&id).is_some() && self.contains(&element) {
-            return Err(InsertionFailure::ElementWithSameValueFound);
+        if self.get(&id).is_none() {
+            return Err(Error::ExpectedElementNotPresent);
         }
 
-        Ok(self._update_value(element, id))
+        Ok(self
+            ._update_value(element, id)
+            .expect("Failed to update value"))
     }
 
     /// Insert a new member to this identified_vec at the specified index, if the identified_vec doesn't already contain

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -554,9 +554,9 @@ where
 
         if let Some(value) = self.get(&id) {
             if value == &element {
-                return Err(Error::ElementWithSameValueFound);
+                return Err(Error::ElementWithSameValueFound(format!("{:#?}", value)));
             } else {
-                return Err(Error::ElementWithSameIDFound);
+                return Err(Error::ElementWithSameIDFound(format!("{:#?}", id)));
             }
         }
 
@@ -581,7 +581,7 @@ where
         let id = self.id(&element);
 
         if self.contains_id(&id) {
-            return Err(Error::ElementWithSameIDFound);
+            return Err(Error::ElementWithSameIDFound(format!("{:#?}", id)));
         }
 
         Ok(self.append(element))
@@ -671,7 +671,7 @@ where
     pub fn try_update(&mut self, element: Element) -> Result<Element, Error> {
         let id = self.id(&element);
         if self.get(&id).is_none() {
-            return Err(Error::ExpectedElementNotPresent);
+            return Err(Error::ExpectedElementNotPresent(format!("{:#?}", id)));
         }
 
         Ok(self

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -538,7 +538,7 @@ where
 impl<ID, Element> IdentifiedVec<ID, Element>
 where
     ID: Eq + Hash + Clone + Debug,
-    Element: Eq + Hash + Clone + Debug,
+    Element: Eq + Debug,
 {
     /// Try append a new unique member to the end of the `identified_vec`, if the `identified_vec` already contains the Value or ID a Error will be returned.
     ///
@@ -554,9 +554,9 @@ where
 
         if let Some(value) = self.get(&id) {
             if value == &element {
-                return Err(Error::ElementWithSameValueFound(format!("{:#?}", value)));
+                return Err(Error::ElementWithSameValueFound(format!("{:?}", value)));
             } else {
-                return Err(Error::ElementWithSameIDFound(format!("{:#?}", id)));
+                return Err(Error::ElementWithSameIDFound(format!("{:?}", id)));
             }
         }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -327,6 +327,16 @@ fn try_append_unique_element() {
     assert!(result.is_err());
     assert_eq!(result, Err(Error::ElementWithSameValueFound(format!("2"))));
     assert_eq!(identified_vec.items(), [1, 2, 3]);
+
+    let mut identified_vec =
+        IdentifiedVecOf::from_iter([User::blob(), User::blob_jr(), User::blob_sr()]);
+    let result = identified_vec.try_append_unique_element(User::new(2, "Blob blob Jr"));
+    assert!(result.is_err());
+    assert_eq!(result, Err(Error::ElementWithSameIDFound(format!("2"))));
+    assert_eq!(
+        identified_vec.items(),
+        [User::blob(), User::blob_jr(), User::blob_sr()]
+    );
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -325,7 +325,7 @@ fn try_append_unique_element() {
     let mut identified_vec = SUT::from_iter([1, 2, 3]);
     let result = identified_vec.try_append_unique_element(2);
     assert!(result.is_err());
-    assert_eq!(result, Err(Error::ElementWithSameValueFound));
+    assert_eq!(result, Err(Error::ElementWithSameValueFound(format!("2"))));
     assert_eq!(identified_vec.items(), [1, 2, 3]);
 }
 
@@ -343,7 +343,7 @@ fn try_append() {
     identified_vec.append(User::blob_sr());
     let result = identified_vec.try_append(User::new(2, "Blob Jr Jr"));
     assert!(result.is_err());
-    assert_eq!(result, Err(Error::ElementWithSameIDFound));
+    assert_eq!(result, Err(Error::ElementWithSameIDFound(format!("2"))));
     assert_eq!(
         identified_vec.items(),
         [User::blob(), User::blob_jr(), User::blob_sr()]
@@ -430,7 +430,7 @@ fn try_update() {
     let mut identified_vec = SUT::from_iter([1, 2, 3]);
     assert_eq!(
         identified_vec.try_update(4),
-        Err(Error::ExpectedElementNotPresent)
+        Err(Error::ExpectedElementNotPresent(format!("4")))
     );
     assert_eq!(identified_vec.items(), [1, 2, 3]);
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -330,9 +330,9 @@ fn try_append_unique_element() {
 }
 
 #[test]
-fn try_append() {
+fn try_append_new_unique_element() {
     let mut identified_vec = SUT::from_iter([1, 2, 3]);
-    let result = identified_vec.try_append(4);
+    let result = identified_vec.try_append_new(4);
     assert!(result.is_ok());
     assert_eq!(result.unwrap().1, 3);
     assert_eq!(identified_vec.items(), [1, 2, 3, 4]);
@@ -341,19 +341,7 @@ fn try_append() {
     identified_vec.append(User::blob());
     identified_vec.append(User::blob_jr());
     identified_vec.append(User::blob_sr());
-    let result = identified_vec.try_append(User::new(2, "Blob Jr Jr"));
-    assert!(result.is_err());
-    assert_eq!(result, Err(Error::ElementWithSameIDFound(format!("2"))));
-    assert_eq!(
-        identified_vec.items(),
-        [User::blob(), User::blob_jr(), User::blob_sr()]
-    );
-
-    let mut identified_vec: Users = IdentifiedVecOf::new();
-    identified_vec.append(User::blob());
-    identified_vec.append(User::blob_jr());
-    identified_vec.append(User::blob_sr());
-    let result = identified_vec.try_append(User::new(4, "Blob Jr Jr"));
+    let result = identified_vec.try_append_new(User::new(4, "Blob Jr Jr"));
     assert!(result.is_ok());
     assert_eq!(result, Ok((true, 3)));
     assert_eq!(
@@ -364,6 +352,21 @@ fn try_append() {
             User::blob_sr(),
             User::new(4, "Blob Jr Jr")
         ]
+    );
+}
+
+#[test]
+fn try_append_element_with_existing_id() {
+    let mut identified_vec: Users = IdentifiedVecOf::new();
+    identified_vec.append(User::blob());
+    identified_vec.append(User::blob_jr());
+    identified_vec.append(User::blob_sr());
+    let result = identified_vec.try_append_new(User::new(2, "Blob Jr Jr"));
+    assert!(result.is_err());
+    assert_eq!(result, Err(Error::ElementWithSameIDFound(format!("2"))));
+    assert_eq!(
+        identified_vec.items(),
+        [User::blob(), User::blob_jr(), User::blob_sr()]
     );
 }
 


### PR DESCRIPTION
Implementation of methods try_append and try_update_or_append adding the function signatures:

`pub fn try_append(&mut self, element: Element) -> Result<(bool, usize), InsertionFailure> {`

and

`    pub fn try_update_or_append(
        &mut self,
        element: Element,
    ) -> Result<Option<Element>, InsertionFailure> {`

This is to add certainties of element value and ID not existing in the collection at call-site.